### PR TITLE
Apache SSL Certs work 

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,9 +1,4 @@
-# == Define: trac::apache
-#
-# Define to handle automatic creation of apache virtualhost. Should be called
-# by tracenv define. This define utilizes the puppetlabs apache module.
-#
-# === Parameters
+# == Define: trac::apache # # Define to handle automatic creation of apache virtualhost. Should be called # by tracenv define. This define utilizes the puppetlabs apache module.  # # === Parameters
 #
 # [*apache_user*]
 #   The name of user the apache service runs under, used to ensure proper
@@ -45,6 +40,8 @@
 define trac::apache(
   $apache_user    = $trac::params::apache_user,
   $apache_group   = $trac::params::apache_group,
+  $apache_ssl_key = undef,
+  $apache_ssl_cert = undef,
   $envpath        = undef,
   $envpath_setype = undef,
   $redir_http     = false,
@@ -86,7 +83,9 @@ define trac::apache(
     port            => '443',
     docroot         => $vhost_docroot,
     ssl             => true,
-    custom_fragment => "WSGIScriptAlias /$name ${envpath}/apache/trac.wsgi", 
+    ssl_key         => $apache_ssl_key,
+    ssl_cert        => $apache_ssl_cert,
+    custom_fragment => "WSGIScriptAlias /$name ${envpath}/apache/trac.wsgi",
       
     directories     => [ 
       { path               => $vhost_docroot, 

--- a/manifests/tracenv.pp
+++ b/manifests/tracenv.pp
@@ -143,6 +143,8 @@ define trac::tracenv(
   $mimeviewer_mime_map_patterns         = 'text/plain:README|INSTALL|COPYING.*',
   $mimeviewer_tab_width                 = '8',
   $mimeviewer_treat_as_binary           = 'application/octet-stream, application/pdf, application/postscript, application/msword,application/rtf,',
+  $mimeviewer_pygments_default_style    = '',
+  $mimeviewer_pygments_modes            = '',
   $notification_admit_domains           = '',
   $notification_always_notify_owner     = false,
   $notification_always_notify_reporter  = false,
@@ -264,6 +266,12 @@ define trac::tracenv(
   $wiki_render_unsafe_content           = false,
   $wiki_safe_schemes                    = 'cvs, file, ftp, git, irc, http, https, news, sftp, smb, ssh, svn, svn+ssh',
   $wiki_split_page_names                = false,
+  $svn_branches                         = 'trunk,branches/*',
+  $svn_tags                             = 'tags/*',
+  $svn_authz_file                       = '',
+  $svn_authz_module_name                = '',
+  $svn_eol_style                        = '',
+  $ticket_custom                        = '',
   $versioncontrol_allowed_repository_dir_prefixes = '',
 ) {
   if ! defined(Class['trac']) {

--- a/manifests/tracenv.pp
+++ b/manifests/tracenv.pp
@@ -101,6 +101,9 @@ define trac::tracenv(
   $adjust_selinux                       = $trac::params::adjust_selinux,
   $apache_group                         = $trac::params::apache_group,
   $apache_user                          = $trac::params::apache_user,
+  $apache_ssl                           = true,
+  $apache_ssl_cert                      = undef,
+  $apache_ssl_key                       = undef,
   $create_db                            = true,
   $create_repo                          = true,
   $create_vhost                         = true,
@@ -137,6 +140,7 @@ define trac::tracenv(
   $logging_custom_log_file              = false,
   $logging_log_level                    = 'DEBUG',
   $logging_log_type                     = 'none',
+  $logging_log_file                     = '',
   $milestone_stats_provider             = 'DefaultTicketGroupStatsProvider',
   $mimeviewer_max_preview_size          = '262144',
   $mimeviewer_mime_map                  = 'text/x-dylan:dylan, text/x-idl:ice, text/x-ada:ads:adb',
@@ -367,13 +371,15 @@ define trac::tracenv(
   # create apache vhost by calling trac::apache
   if $create_vhost {
     trac::apache{$name:
-      apache_user    => $apache_user,
-      apache_group   => $apache_group,
-      envpath        => $envpath,
-      envpath_setype => $envpath_setype,
-      vhost_name     => $vhost_name,
-      vhost_docroot  => $vhost_docroot,
-      redir_http     => $redir_http,
+      apache_user     => $apache_user,
+      apache_group    => $apache_group,
+      envpath         => $envpath,
+      envpath_setype  => $envpath_setype,
+      vhost_name      => $vhost_name,
+      vhost_docroot   => $vhost_docroot,
+      redir_http      => $redir_http,
+      apache_ssl_key  => $apache_ssl_key,
+      apache_ssl_cert => $apache_ssl_cert,
     }
   }
  

--- a/templates/trac.ini.erb
+++ b/templates/trac.ini.erb
@@ -59,6 +59,8 @@ mime_map = <%= @mimeviewer_mime_map %>
 mime_map_patterns = <%= @mimeviewer_mime_map_patterns %>
 tab_width = <%= @mimeviewer_tab_width %>
 treat_as_binary = <%= @mimeviewer_treat_as_binary %>
+pygments_default_style = <%= @mimeviewer_pygments_default_style %>
+pygments_modes = <%= @mimeviewer_pygments_modes %>
 
 [notification]
 admit_domains = <%= @notification_admit_domains %>
@@ -205,6 +207,13 @@ show_ip_addresses = <%= @trac_show_ip_addresses %>
 timeout = <%= @trac_timeout %>
 use_base_url_for_redirect = <%= @trac_use_base_url_for_redirect %>
 
+[svn]
+authz_file = <%= @svn_authz_file %>
+authz_module_name = <%= @svn_authz_module_name %>
+eol_style = <%= @svn_eol_style %>
+branches = <%= @svn_branches %>
+tags = <%= @svn_tags %>
+
 [versioncontrol]
 allowed_repository_dir_prefixes = <%= @versioncontrol_allowed_repository_dir_prefixes %>
 
@@ -214,3 +223,6 @@ max_size = <%= @wiki_max_size %>
 render_unsafe_content = <%= @wiki_render_unsafe_content %>
 safe_schemes = <%= @wiki_safe_schemes %>
 split_page_names = <%= @wiki_split_page_names %>
+
+[ticket-custom]
+<%= @ticket_custom %>


### PR DESCRIPTION
Fixed the certs so that you can provide a path to the SSL cert and key: 

trac::tracenv{'MyProject':
   apache_ssl_cert => "/etc/apache2/certs/mydomain.crt", 
   apache_ssl_key => "/etc/apache2/certs/mydomain.key", 
...
}

Note that actually putting the files in place is left as an exercise for the reader. These don't create file objects, they just populate the SSLCertificateFile and SSLCertificateKeyFile directives in /etc/apache2/sites-enabled/25-instance.conf, so they can still be managed by puppet. 

A relatively small, and hopefully innocuous addition to the [svn] config was added in trac.ini. This shouldn't be harmful because the default values should be fine. 
